### PR TITLE
fix: remove console.log statements from frontend UI flows

### DIFF
--- a/frontend/src/components/AddAdmin.jsx
+++ b/frontend/src/components/AddAdmin.jsx
@@ -41,7 +41,6 @@ const AddAdmin = () => {
 				newAdminData,
 				{ headers: { token: localStorage.getItem('token') } }
 			);
-			console.log(createAdminResponse);
 			if (createAdminResponse.status === 200) {
 				toast.success(createAdminResponse.data.msg);
 				// Reset form after successful admin creation

--- a/frontend/src/components/AddPapers.jsx
+++ b/frontend/src/components/AddPapers.jsx
@@ -40,7 +40,6 @@ const AddPaper = () => {
           },
         }
       );
-      console.log(response);
       if (response.status === 201) {
         toast.success(response.data.message);
         setHeading('');

--- a/frontend/src/components/AddSpeakers.jsx
+++ b/frontend/src/components/AddSpeakers.jsx
@@ -65,7 +65,6 @@ const AddSpeaker = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.message);
           setName('');

--- a/frontend/src/components/AllSpeakers.jsx
+++ b/frontend/src/components/AllSpeakers.jsx
@@ -20,7 +20,6 @@ const AllSpeakers = () => {
         const response = await axios.get(
           `${import.meta.env.VITE_API_URL}/speaker/all`
         );
-        console.log(response.data)
         setSpeakers(response.data);
         // Initialize priorities state with current speaker priorities
         const initialPriorities = {};

--- a/frontend/src/components/IndustryProgrammeCommittee/AddMember.jsx
+++ b/frontend/src/components/IndustryProgrammeCommittee/AddMember.jsx
@@ -61,7 +61,6 @@ const AddIndustryProgrammeCommitteeMember = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.msg);
           setImage(null);

--- a/frontend/src/components/IndustryProgrammeCommittee/UpdateMember.jsx
+++ b/frontend/src/components/IndustryProgrammeCommittee/UpdateMember.jsx
@@ -26,7 +26,6 @@ const UpdateIndustryProgrammeMember = () => {
               headers:{token:localStorage.getItem("token")}
           });
           const member=res.data.member;
-          console.log(member);
           setOrganisingMemberData({
               college:member.college,
               committee:member.committee,
@@ -90,7 +89,6 @@ const UpdateIndustryProgrammeMember = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.msg);
           setImage(null);

--- a/frontend/src/components/InternationalCommittee/AddMember.jsx
+++ b/frontend/src/components/InternationalCommittee/AddMember.jsx
@@ -61,7 +61,6 @@ const InternationalMember = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.msg);
           setImage(null);

--- a/frontend/src/components/InternationalCommittee/UpdateMember.jsx
+++ b/frontend/src/components/InternationalCommittee/UpdateMember.jsx
@@ -26,7 +26,6 @@ const UpdateInternationalMember = () => {
               headers:{token:localStorage.getItem("token")}
           });
           const member=res.data.member;
-          console.log(member);
           setOrganisingMemberData({
               college:member.college,
               committee:member.committee,
@@ -89,7 +88,6 @@ const UpdateInternationalMember = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.msg);
           setImage(null);

--- a/frontend/src/components/OrganisingCommittee/AddOrganisingCommitteeMember.jsx
+++ b/frontend/src/components/OrganisingCommittee/AddOrganisingCommitteeMember.jsx
@@ -78,7 +78,6 @@ const AddOrganisingCommitteeMember = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.msg);
           setImage(null);

--- a/frontend/src/components/OrganisingCommittee/UpdateMember.jsx
+++ b/frontend/src/components/OrganisingCommittee/UpdateMember.jsx
@@ -43,7 +43,6 @@ const UpdateMember = () => {
               headers:{token:localStorage.getItem("token")}
           });
           const member=res.data.member;
-          console.log(member);
           setOrganisingMemberData({
               college:member.college,
               committee:member.committee,
@@ -106,7 +105,6 @@ const UpdateMember = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.msg);
           setImage(null);

--- a/frontend/src/components/TechnicalCommittee/AddMember.jsx
+++ b/frontend/src/components/TechnicalCommittee/AddMember.jsx
@@ -61,7 +61,6 @@ const AddTechnicalCommitteeMember = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.msg);
           setImage(null);

--- a/frontend/src/components/TechnicalCommittee/UpdateMember.jsx
+++ b/frontend/src/components/TechnicalCommittee/UpdateMember.jsx
@@ -26,7 +26,6 @@ const UpdateTechnicalMember = () => {
               headers:{token:localStorage.getItem("token")}
           });
           const member=res.data.member;
-          console.log(member);
           setOrganisingMemberData({
               college:member.college,
               committee:member.committee,
@@ -89,7 +88,6 @@ const UpdateTechnicalMember = () => {
             },
           }
         );
-        console.log(response);
         if (response.status === 201) {
           toast.success(response.data.msg);
           setImage(null);

--- a/frontend/src/components/programscomp/ThreeSpeakers.jsx
+++ b/frontend/src/components/programscomp/ThreeSpeakers.jsx
@@ -15,7 +15,6 @@ const AllSpeakerprog = () => {
                 const response = await axios.get(
                     `${import.meta.env.VITE_API_URL}/speaker/all`
                 );
-                console.log(response.data)
                 setSpeakers(response.data.slice(0, 3));
             } catch (error) {
                 console.error('Error fetching speakers:', error);

--- a/frontend/src/routes/Login.jsx
+++ b/frontend/src/routes/Login.jsx
@@ -21,7 +21,6 @@ export default function Login({setfetch}) {
 
       if (response.data.token) {
         localStorage.setItem("token", response.data.token);
-        console.log(response.data);
         // Show success toast
         localStorage.setItem("photo", response.data?.user?.photo);
         localStorage.setItem("name", response.data?.user?.name);


### PR DESCRIPTION
## 🧾 Description
Removes leftover console.log statements from frontend components to prevent sensitive runtime info from being exposed in the browser console and to keep the console clean in production.

Fixes #7

## 🧩 Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / maintenance

## 🧪 How to test
- [ ] Frontend: `npm run dev`
- Open browser DevTools → Console tab
- Navigate to Login page and committee pages
- Verify no console.log output appears

## ✅ Checklist
- [x] I ran the app locally and verified the change
- [x] I updated documentation when needed
- [x] I did a self-review
- [x] I didn't include secrets in commits