### PR TITLE
fix: add validation to ContactForm (email, subject, phone, message)

### DIFF
--- a/frontend/src/components/ContactForm.jsx
+++ b/frontend/src/components/ContactForm.jsx
@@ -1,5 +1,19 @@
 import React, { useState } from 'react';
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^[\d\s+\-().]{7,15}$/;
+
+const validate = ({ email, subject, phone, message }) => {
+  const errs = {};
+  if (!EMAIL_RE.test(email)) errs.email = 'Enter a valid email address.';
+  if (subject.trim().length < 5) errs.subject = 'Subject must be at least 5 characters.';
+  if (subject.trim().length > 100) errs.subject = 'Subject must be 100 characters or fewer.';
+  if (phone && !PHONE_RE.test(phone)) errs.phone = 'Enter a valid phone number (7–15 digits).';
+  if (message.trim().length < 20) errs.message = 'Message must be at least 20 characters.';
+  if (message.trim().length > 1000) errs.message = 'Message must be 1000 characters or fewer.';
+  return errs;
+};
+
 const ContactForm = () => {
   const [formData, setFormData] = useState({
     name: '',
@@ -8,6 +22,7 @@ const ContactForm = () => {
     phone: '',
     message: '',
   });
+  const [errors, setErrors] = useState({});
 
   const handleChange = (e) => {
     setFormData((prev) => ({
@@ -18,6 +33,9 @@ const ContactForm = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    const errs = validate(formData);
+    if (Object.keys(errs).length) { setErrors(errs); return; }
+    setErrors({});
     try {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/contact`, {
         method: 'POST',
@@ -65,6 +83,7 @@ const ContactForm = () => {
           required
           className="w-full border border-gray-300 p-3 rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
         />
+        {errors.email && <p className="text-red-500 text-sm -mt-2">{errors.email}</p>}
         <input
           type="text"
           name="subject"
@@ -74,14 +93,16 @@ const ContactForm = () => {
           required
           className="w-full border border-gray-300 p-3 rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
         />
+        {errors.subject && <p className="text-red-500 text-sm -mt-2">{errors.subject}</p>}
         <input
           type="tel"
           name="phone"
-          placeholder="Phone"
+          placeholder="Phone (optional)"
           value={formData.phone}
           onChange={handleChange}
           className="w-full border border-gray-300 p-3 rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
         />
+        {errors.phone && <p className="text-red-500 text-sm -mt-2">{errors.phone}</p>}
         <textarea
           name="message"
           placeholder="Message"
@@ -91,6 +112,7 @@ const ContactForm = () => {
           rows="4"
           className="w-full border border-gray-300 p-3 rounded focus:outline-none focus:ring-2 focus:ring-yellow-400"
         />
+        {errors.message && <p className="text-red-500 text-sm -mt-2">{errors.message}</p>}
         <button
           type="submit"
           className="w-full bg-yellow-400 text-black font-bold py-2 rounded hover:bg-yellow-500 transition"


### PR DESCRIPTION
NSoC'26

## 🧾 Description
Improve contact form validation with user-friendly inline error messages.
- Email: validated against regex format
- Subject: must be 5–100 characters
- Phone: optional, but if provided must be 7–15 digits
- Message: must be 20–1000 characters

Fixes #16 

## 🧩 Type of change
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / maintenance

## 🧪 How to test

-  Frontend: `npm run dev` inside `frontend/`
- Navigate to the Contact page and try submitting with:
  - Invalid email (e.g. `abc`) → should show "Enter a valid email address."
  - Subject shorter than 5 chars → should show "Subject must be at least 5 characters."
  - Phone with less than 7 digits → should show "Enter a valid phone number (7–15 digits)."
  - Message shorter than 20 chars → should show "Message must be at least 20 characters."
  - All valid inputs → form submits successfully with no errors

## 📸 Screenshots
<img width="588" height="281" alt="image" src="https://github.com/user-attachments/assets/c475689d-5a9d-4d94-9af5-3c9eccb6cfcf" />
<img width="453" height="307" alt="image" src="https://github.com/user-attachments/assets/5739f7e3-138d-45e4-8bdc-bc1623953177" />
<img width="416" height="95" alt="image" src="https://github.com/user-attachments/assets/ae4b2834-2547-4016-ba36-42efaf6f812e" />



## ✅ Checklist

- [x] I ran the app locally and verified the change
- [ ] I updated documentation when needed
- [x] I did a self-review
- [x] I didn't include secrets in commits
