### PR TITLE
Implements client-side validation for image uploads across all frontend upload forms

### DIFF
--- a/frontend/src/components/AddPhotoGallery.jsx
+++ b/frontend/src/components/AddPhotoGallery.jsx
@@ -14,9 +14,22 @@ const AddPhotoGallery = () => {
   // Handle image selection and show preview
   const handleImageChange = (e) => {
     const file = e.target.files[0];
-    setImage(file);
-    const imageUr = URL.createObjectURL(file);
-    setImageUrl(imageUr);
+    if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
+      setImage(file);
+      const imageUr = URL.createObjectURL(file);
+      setImageUrl(imageUr);
+    }
   };
 
   // Handle form submission

--- a/frontend/src/components/AddSpeakers.jsx
+++ b/frontend/src/components/AddSpeakers.jsx
@@ -16,6 +16,17 @@ const AddSpeaker = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUr = URL.createObjectURL(file);
       setImageUrl(imageUr);

--- a/frontend/src/components/IndustryProgrammeCommittee/AddMember.jsx
+++ b/frontend/src/components/IndustryProgrammeCommittee/AddMember.jsx
@@ -20,6 +20,17 @@ const AddIndustryProgrammeCommitteeMember = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUrl = URL.createObjectURL(file);
       setOrganisingMemberData({...organisingMemberData,imageUrl});

--- a/frontend/src/components/IndustryProgrammeCommittee/UpdateMember.jsx
+++ b/frontend/src/components/IndustryProgrammeCommittee/UpdateMember.jsx
@@ -48,6 +48,17 @@ const UpdateIndustryProgrammeMember = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUrl = URL.createObjectURL(file);
       setOrganisingMemberData({...organisingMemberData,imageUrl});

--- a/frontend/src/components/InternationalCommittee/AddMember.jsx
+++ b/frontend/src/components/InternationalCommittee/AddMember.jsx
@@ -20,6 +20,17 @@ const InternationalMember = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUrl = URL.createObjectURL(file);
       setOrganisingMemberData({...organisingMemberData,imageUrl});

--- a/frontend/src/components/InternationalCommittee/UpdateMember.jsx
+++ b/frontend/src/components/InternationalCommittee/UpdateMember.jsx
@@ -47,6 +47,17 @@ const UpdateInternationalMember = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUrl = URL.createObjectURL(file);
       setOrganisingMemberData({...organisingMemberData,imageUrl});

--- a/frontend/src/components/OrganisingCommittee/AddOrganisingCommitteeMember.jsx
+++ b/frontend/src/components/OrganisingCommittee/AddOrganisingCommitteeMember.jsx
@@ -37,6 +37,17 @@ const AddOrganisingCommitteeMember = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUrl = URL.createObjectURL(file);
       setOrganisingMemberData({...organisingMemberData,imageUrl});

--- a/frontend/src/components/OrganisingCommittee/UpdateMember.jsx
+++ b/frontend/src/components/OrganisingCommittee/UpdateMember.jsx
@@ -64,6 +64,17 @@ const UpdateMember = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUrl = URL.createObjectURL(file);
       setOrganisingMemberData({...organisingMemberData,imageUrl});

--- a/frontend/src/components/TechnicalCommittee/AddMember.jsx
+++ b/frontend/src/components/TechnicalCommittee/AddMember.jsx
@@ -20,6 +20,17 @@ const AddTechnicalCommitteeMember = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUrl = URL.createObjectURL(file);
       setOrganisingMemberData({...organisingMemberData,imageUrl});

--- a/frontend/src/components/TechnicalCommittee/UpdateMember.jsx
+++ b/frontend/src/components/TechnicalCommittee/UpdateMember.jsx
@@ -47,6 +47,17 @@ const UpdateTechnicalMember = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUrl = URL.createObjectURL(file);
       setOrganisingMemberData({...organisingMemberData,imageUrl});

--- a/frontend/src/components/UpdateSpeaker.jsx
+++ b/frontend/src/components/UpdateSpeaker.jsx
@@ -52,6 +52,17 @@ const UpdateSpeaker = () => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
+      if (!file.type.startsWith('image/')) {
+        toast.error('Please upload an image file (JPEG, PNG, etc.)');
+        e.target.value = null;
+        return;
+      }
+      const maxSize = 2 * 1024 * 1024; // 2MB
+      if (file.size > maxSize) {
+        toast.error('File size must be less than 2MB');
+        e.target.value = null;
+        return;
+      }
       setImage(file);
       const imageUr = URL.createObjectURL(file);
       setSpeaker({ ...speaker, imageUrl: imageUr });


### PR DESCRIPTION
## 🧾 Description

Implements client-side validation for image uploads across all frontend upload forms (Speakers, Gallery, and Committee) to improve user experience and reduce unnecessary backend load.

Previously, users could upload unsupported file types or oversized images, resulting in failed uploads after submission. This change introduces immediate validation before upload to ensure only valid files are processed.

### Key improvements:

* Enforces **image-only MIME types** (e.g., `image/jpeg`, `image/png`, `image/webp`)
* Adds a **file size limit** (maximum 2MB per image; centralized and configurable)
* Displays **clear toast error messages** for invalid uploads (type and size violations)
* Prevents invalid files from being sent to the backend, reducing bandwidth usage and processing cost

Fixes #<!-- issue number, if applicable -->

---

## 🧩 Type of change

* [x] Bug fix (non-breaking)
* [x] New feature (non-breaking)
* [ ] Breaking change
* [ ] Documentation update
* [x] Refactor / maintenance

---

## 🧪 How to test

List the exact steps/commands to verify the change:

* [ ] Backend: `pnpm run dev` (or `npm run dev`)
* [ ] Frontend: `pnpm run dev` (or `npm run dev`)
* [ ] API: call endpoint(s) affected

### Manual testing steps:

1. Navigate to any upload form (Speakers / Gallery / Committee)
2. Try uploading a non-image file (e.g., `.pdf`, `.txt`) → expect toast error
3. Try uploading an image larger than 2MB → expect toast error
4. Upload a valid image under size limit → should succeed
5. Verify no invalid request is sent to backend for rejected files

---


## ✅ Checklist

* [x] I ran the app locally and verified the change
* [x] I updated documentation when needed
* [x] I did a self-review
* [x] I didn’t include secrets in commits

Closes #15 