### PR TITLE
fix: replace alert() with react-toastify toasts in ContactForm

### DIFF
--- a/frontend/src/components/ContactForm.jsx
+++ b/frontend/src/components/ContactForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { toast } from 'react-toastify';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_RE = /^[\d\s+\-().]{7,15}$/;
@@ -44,7 +45,7 @@ const ContactForm = () => {
       });
 
       const result = await res.json();
-      alert(result.message);
+      toast.success(result.message || 'Message sent successfully!');
 
       // Clear the form
       setFormData({
@@ -56,7 +57,7 @@ const ContactForm = () => {
       });
     } catch (err) {
       console.error(err);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
     }
   };
 


### PR DESCRIPTION
Contributing under NSoC'26
## 🧾 Description
Replace blocking `alert()` with `react-toastify` toasts in ContactForm.

Fixes #6 
## 🧩 Type of change
- [x] Bug fix (non-breaking)

## 🧪 How to test
- `npm run dev` inside `frontend/`
- Submit valid form → green success toast
- Disconnect network + submit → red error toast

## 📸 Screenshots
<img width="426" height="185" alt="image" src="https://github.com/user-attachments/assets/50237c54-d847-4b3e-ac57-3281939a5bfe" />

## ✅ Checklist
- [x] I ran the app locally and verified the change
- [x] I did a self-review
- [x] I didn't include secrets in commits
